### PR TITLE
change type of extraEnvVarsSecrets to string

### DIFF
--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -306,7 +306,7 @@
                     "type": "array",
                     "description": "Translates into array of `envFrom.[].secretRef.name`",
                     "items": {
-                        "type": "object"
+                        "type": "string"
                     },
                     "default": [],
                     "examples": [


### PR DESCRIPTION
providing a valid secret name as an array item is resulting in the error `backstage.extraEnvVarsSecrets.0: Invalid type. Expected: object, given: string`
```
 extraEnvVarsSecrets:
    - <secret-name>
```

